### PR TITLE
[ADD]PreviewMode

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -1,11 +1,22 @@
 import styled from 'styled-components'
 import Footer from 'components/Footer'
 import Header from 'components/Header'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
 
 const About = () => {
+  const router = useRouter()
+  const getPreview = () => {
+    fetch('http://localhost:3000/api/productList')
+    // router.push('/contact')
+  }
+
   return (
     <AboutTitle>
-      <a href="/about">About</a>
+      <Link href="/about">
+        <a>About</a>
+      </Link>
+      <button onClick={getPreview}>go contact</button>
     </AboutTitle>
   )
 }

--- a/pages/api/productList/index.js
+++ b/pages/api/productList/index.js
@@ -1,9 +1,10 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
-import { DATA } from 'data/productLists'
-
 export default function handler(req, res) {
   if (req.method === 'GET') {
-    res.status(200).json(DATA)
+    // res.status(200).json(DATA)
+    res.setPreviewData({ title: 'unbelievable' })
+    // res.status(200).json('preview mode activate')
+    res.redirect('/contact')
   }
 }

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,8 +1,15 @@
 import styled from 'styled-components'
 import Header from 'components/Header'
+import { useEffect } from 'react'
 
-const Contact = () => {
-  return <ContactTitle>Contact</ContactTitle>
+const Contact = props => {
+  // useEffect(() => {
+  //   fetch('http://localhost:3000/api/productList')
+  //     .then(res => res.json())
+  //     .then(res => console.log(res))
+  // })
+
+  return <ContactTitle>{props.data}</ContactTitle>
 }
 
 export default Contact
@@ -13,6 +20,15 @@ const ContactTitle = styled.h1`
   align-items: center;
   min-height: 100vh;
 `
+
+export async function getStaticProps(context) {
+  console.log(context)
+  return {
+    props: context.preview
+      ? { data: context.previewData.title }
+      : { data: 'normal Page' },
+  }
+}
 
 Contact.getLayout = function getLayout(page) {
   return (


### PR DESCRIPTION
setPreviewData()에 따른 정적페이지의 preview 모드 활성화 여부

api 의 응답으로 res.setPreviewData() 를 하게되면 cookie 로 두가지 값이 들어오게 된다 (__next_preview_data // __prerender_bypass)

이 쿠키값이 존재하는가에 따라 정적페이지에서는 context 에 preview 와 previewData 두가지 값이 들어오게되고,

쿠키값이 존재할때는 preview가 true로, 없을때는 false로 값이 들어오게되므로, preview에 따라서 

정적페이지를 다르게 나타내어줄 수 있다.( build 가 아닌 request 마다 정적페이지를 생성할 수 있게된다.)