### PR TITLE
[ADD]custom Login

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,16 +1,17 @@
 import Link from 'next/link'
 import styled from 'styled-components'
-import { signIn, signOut } from 'next-auth/react'
+import { signOut, useSession } from 'next-auth/react'
 import { useRouter } from 'next/router'
 
 const Header = () => {
   const router = useRouter()
-  const signInHandler = () => {
-    signIn()
-  }
+  const session = useSession()
+
+  console.log(session)
 
   const signOutHandler = () => {
-    signOut('github')
+    signOut()
+    // signOut({ callbackUrl: 'http://localhost:3000/contact' })
   }
 
   return (
@@ -32,8 +33,14 @@ const Header = () => {
             <a>product</a>
           </Link>
         </Listitem>
-        <Listitem onClick={signInHandler}>SignIn</Listitem>
-        <Listitem onClick={signOutHandler}>Signout</Listitem>
+        {!session.data && (
+          <Listitem>
+            <Link href="/login">
+              <a>SignIn</a>
+            </Link>
+          </Listitem>
+        )}
+        {session.data && <Listitem onClick={signOutHandler}>Signout</Listitem>}
       </NavList>
     </HeaderTitle>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
   if (Component.getLayout) {
     return Component.getLayout(
       <SessionProvider session={session}>
+        <Header />
         <Component {...pageProps} />
       </SessionProvider>,
     )
@@ -21,8 +22,8 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
         <meta name="description" content="넥스트 연습해보기" />
       </Head>
       <GlobalStyles />
-      <Header />
       <SessionProvider session={session}>
+        <Header />
         <Component {...pageProps} />
       </SessionProvider>
     </>

--- a/pages/about.js
+++ b/pages/about.js
@@ -58,7 +58,6 @@ About.getLayout = function getLayout(page) {
       <Head>
         <title>AboutPage</title>
       </Head>
-      <Header />
       {page}
       <Footer />
     </>

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -15,15 +15,17 @@ const USER = [
 export const authOptions = {
   providers: [
     GitHubProvider({
+      id: 'githubLogin',
       clientId: process.env.GITHUB_ID,
       clientSecret: process.env.GITHUB_SECRET,
     }),
     CredentialsProvider({
+      id: 'creditLogin',
       name: 'Credentials',
-      credentials: {
-        username: { label: 'Username', type: 'text', placeholder: 'jsmith' },
-        password: { label: 'Password', type: 'password' },
-      },
+      // credentials: {
+      //   username: { label: 'Username', type: 'text', placeholder: 'jsmith' },
+      //   password: { label: 'Password', type: 'password' },
+      // },
       async authorize(credentials, req) {
         const user = USER.filter(
           el =>

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -38,7 +38,6 @@ Contact.getLayout = function getLayout(page) {
       <Head>
         <title>Contact Page</title>
       </Head>
-      <Header />
       {page}
       <Footer />
     </>

--- a/pages/login.js
+++ b/pages/login.js
@@ -1,0 +1,79 @@
+import { getProviders, signIn } from 'next-auth/react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+
+const Login = () => {
+  const [userId, setUserId] = useState('')
+  const [userPassword, setUserPassword] = useState('')
+  const router = useRouter()
+  const providers = getProviders()
+
+  const loginHandler = async () => {
+    const status = await signIn('creditLogin', {
+      redirect: false,
+      username: userId,
+      password: userPassword,
+      callbackUrl: 'http://localhost:3000/about',
+    })
+    const provid = await getProviders()
+    console.log(provid)
+    if (status.ok) router.push('/')
+  }
+
+  const githubHandler = async () => {
+    signIn('githubLogin')
+  }
+
+  return (
+    <>
+      <div>
+        <input
+          type="text"
+          onChange={({ target }) => {
+            setUserId(target.value)
+          }}
+          placeholder="아이디를 입력해주세요"
+        />
+
+        <input
+          type="password"
+          onChange={({ target }) => {
+            setUserPassword(target.value)
+          }}
+          placeholder="비밀번호를 입력해주세요"
+        />
+        <button onClick={loginHandler}>Login</button>
+        <button onClick={githubHandler}>github Login</button>
+      </div>
+      <style jsx>{`
+        div {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          height: 500px;
+        }
+        input {
+          width: 300px;
+          height: 40px;
+          margin-bottom: 30px;
+          padding: 8px;
+          font-size: 16px;
+          border: 1px solid #cacaca;
+          border-radius: 10px;
+          outline: none;
+        }
+        button {
+          width: 300px;
+          height: 40px;
+          border: 1px solid #cacaca;
+          border-radius: 10px;
+          background-color: white;
+          cursor: pointer;
+        }
+      `}</style>
+    </>
+  )
+}
+
+export default Login


### PR DESCRIPTION
로그인페이지 따로 구현하기

로그인 페이지를 따로 만들어주고 난 후에, 해당 페이지에서 로그인 버튼에 각각 signIn() 함수를 불러내어 로그인을 진행 할 수 있다.
api의 ...nextauth.js 에서 provider을 지정할때 id값을 넣어주면 signIn() 함수의 첫번째 인자로 id 를 가져오게 되면 해당 로그인을 구현하게 된다.
credential의 경우 두번째 인자로 로그인 정보를 넘겨주게되면 ...nextauth.js 에서 authorize() 함수의 첫번째 인자로 signIn으로 넘겨준 값들을 받아올 수 있다.
