### PR TITLE
[ADD]쿼리를 활용한 서버사이드 랜더링

### DIFF
--- a/components/Items.js
+++ b/components/Items.js
@@ -1,0 +1,9 @@
+import React from 'react'
+import { useProducts } from 'utils/useProducts'
+
+const Items = () => {
+  const { data, isLoading } = useProducts()
+  return data?.map(item => <div key={item.id}>{item.name}</div>)
+}
+
+export default Items

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "nextplay",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^4.19.1",
+        "@tanstack/react-query-devtools": "^4.19.1",
         "date-fns": "^2.29.3",
         "gray-matter": "^4.0.3",
         "json-server": "^0.17.1",
@@ -682,6 +684,75 @@
       "integrity": "sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.0.tgz",
+      "integrity": "sha512-OgfIPMHTfuw9JGcXCCoEHWFP/eSP2eyhCYwkrFnWBM3NbUPAgOlFP11DbM7cozDRVB0XbPr1tD4pLAtWKlVUVg==",
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.19.1.tgz",
+      "integrity": "sha512-Zp0aIose5C8skBzqbVFGk9HJsPtUhRVDVNWIqVzFbGQQgYSeLZMd3Sdb4+EnA5wl1J7X+bre2PJGnQg9x/zHOA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.19.1.tgz",
+      "integrity": "sha512-5dvHvmc0vrWI03AJugzvKfirxCyCLe+qawrWFCXdu8t7dklIhJ7D5ZhgTypv7mMtIpdHPcECtCiT/+V74wCn2A==",
+      "dependencies": {
+        "@tanstack/query-core": "4.19.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.19.1.tgz",
+      "integrity": "sha512-U63A+ly9JLPJj7ryR9omdXT3n+gS7jlExrHty4klsd/6xdUhC38CKZyZ0Gi3vctaVYRGTU8/vI+uKzBYdFqLaA==",
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.19.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@types/debug": {
@@ -1363,6 +1434,20 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/core-js-pure": {
       "version": "3.25.5",
@@ -3062,6 +3147,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4722,6 +4818,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5214,6 +5315,17 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -6146,6 +6258,38 @@
         "tslib": "^2.4.0"
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.7.0.tgz",
+      "integrity": "sha512-OgfIPMHTfuw9JGcXCCoEHWFP/eSP2eyhCYwkrFnWBM3NbUPAgOlFP11DbM7cozDRVB0XbPr1tD4pLAtWKlVUVg==",
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.19.1.tgz",
+      "integrity": "sha512-Zp0aIose5C8skBzqbVFGk9HJsPtUhRVDVNWIqVzFbGQQgYSeLZMd3Sdb4+EnA5wl1J7X+bre2PJGnQg9x/zHOA=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.19.1.tgz",
+      "integrity": "sha512-5dvHvmc0vrWI03AJugzvKfirxCyCLe+qawrWFCXdu8t7dklIhJ7D5ZhgTypv7mMtIpdHPcECtCiT/+V74wCn2A==",
+      "requires": {
+        "@tanstack/query-core": "4.19.1",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.19.1.tgz",
+      "integrity": "sha512-U63A+ly9JLPJj7ryR9omdXT3n+gS7jlExrHty4klsd/6xdUhC38CKZyZ0Gi3vctaVYRGTU8/vI+uKzBYdFqLaA==",
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.7.0",
+        "superjson": "^1.10.0",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@types/debug": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
@@ -6626,6 +6770,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "copy-anything": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.3.tgz",
+      "integrity": "sha512-fpW2W/BqEzqPp29QS+MwwfisHCQZtiduTe/m8idFo0xbti9fIZ2WVhAsCv4ggFVH3AgCkVdpoOCtQC6gBrdhjw==",
+      "requires": {
+        "is-what": "^4.1.8"
+      }
     },
     "core-js-pure": {
       "version": "3.25.5",
@@ -7874,6 +8026,11 @@
         "call-bind": "^1.0.2"
       }
     },
+    "is-what": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.8.tgz",
+      "integrity": "sha512-yq8gMao5upkPoGEU9LsB2P+K3Kt8Q3fQFCGyNCWOAnJAMzEXVV9drYb0TXr42TTliLLhKIBvulgAXgtLLnwzGA=="
+    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -8967,6 +9124,11 @@
         "unified": "^10.0.0"
       }
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9326,6 +9488,14 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
       "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
       "requires": {}
+    },
+    "superjson": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.11.0.tgz",
+      "integrity": "sha512-6PfAg1FKhqkwWvPb2uXhH4MkMttdc17eJ91+Aoz4s1XUEDZFmLfFx/xVA3wgkPxAGy5dpozgGdK6V/n20Wj9yg==",
+      "requires": {
+        "copy-anything": "^3.0.2"
+      }
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "serve-json": "json-server --watch db.json --port 4000"
   },
   "dependencies": {
+    "@tanstack/react-query": "^4.19.1",
+    "@tanstack/react-query-devtools": "^4.19.1",
     "date-fns": "^2.29.3",
     "gray-matter": "^4.0.3",
     "json-server": "^0.17.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,9 +37,11 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
       <GlobalStyles />
       <SessionProvider session={session}>
         <QueryClientProvider client={queryClient}>
-          <Header />
-          <Component {...pageProps} />
-          <ReactQueryDevtools initialIsOpen />
+          <Hydrate state={pageProps.dehydratedState}>
+            <Header />
+            <Component {...pageProps} />
+            <ReactQueryDevtools initialIsOpen />
+          </Hydrate>
         </QueryClientProvider>
       </SessionProvider>
     </>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,13 +2,26 @@ import GlobalStyles from 'styles/_GlobalStyles'
 import Head from 'next/head'
 import Header from 'components/Header'
 import { SessionProvider } from 'next-auth/react'
+import {
+  Hydrate,
+  QueryClient,
+  QueryClientProvider,
+} from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }) {
+  const queryClient = new QueryClient()
+
   if (Component.getLayout) {
     return Component.getLayout(
       <SessionProvider session={session}>
-        <Header />
-        <Component {...pageProps} />
+        <QueryClientProvider client={queryClient}>
+          <Hydrate state={pageProps.dehydratedState}>
+            <Header />
+            <Component {...pageProps} />
+            <ReactQueryDevtools initialIsOpen />
+          </Hydrate>
+        </QueryClientProvider>
       </SessionProvider>,
     )
   }
@@ -23,8 +36,11 @@ function MyApp({ Component, pageProps: { session, ...pageProps } }) {
       </Head>
       <GlobalStyles />
       <SessionProvider session={session}>
-        <Header />
-        <Component {...pageProps} />
+        <QueryClientProvider client={queryClient}>
+          <Header />
+          <Component {...pageProps} />
+          <ReactQueryDevtools initialIsOpen />
+        </QueryClientProvider>
       </SessionProvider>
     </>
   )

--- a/pages/about.js
+++ b/pages/about.js
@@ -7,15 +7,41 @@ import Head from 'next/head'
 import { getSession, useSession } from 'next-auth/react'
 import { unstable_getServerSession } from 'next-auth'
 import { authOptions } from './api/auth/[...nextauth]'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { getProductItem } from 'utils/getProductItem'
+import { getProductLists } from 'utils/getProductLists'
+import { useState } from 'react'
 
 const About = ({ data }) => {
+  const [count, setCount] = useState('23')
+  const queryClient = useQueryClient()
+  console.log(queryClient)
+  const query = useQuery(['about', count], () => getProductItem(count), {
+    refetchOnWindowFocus: false,
+    // staleTime: 20000,
+    initialData: async () => {
+      const initialData = await getProductLists()
+      console.log(initialData)
+      const filterItem = initialData.filter(
+        item => item.id === Number(count),
+      )[0]
+      console.log('/////', filterItem, '////')
+      return filterItem ?? undefined
+    },
+  })
+  console.log(query.data, query.isLoading)
   const router = useRouter()
+
   const getPreview = () => {
     fetch('http://localhost:3000/api/productList')
     // router.push('/contact')
   }
-  const { data: session, status } = useSession()
-  console.log(session, '/////', status, '///////', data)
+  // const { data: session, status } = useSession()
+  // console.log(session, '/////', status, '///////', data)
+
+  const countHandler = e => {
+    setCount(e.target.value)
+  }
 
   return (
     <AboutTitle>
@@ -23,8 +49,9 @@ const About = ({ data }) => {
         <a>About</a>
       </Link>
       <br></br>
-      {session ? <p>login success</p> : <p>Login Plz</p>}
+      {/* {session ? <p>login success</p> : <p>Login Plz</p>} */}
       <button onClick={getPreview}>go contact</button>
+      <input type="text" onChange={countHandler} defaultValue="23"></input>
     </AboutTitle>
   )
 }

--- a/pages/about.js
+++ b/pages/about.js
@@ -18,7 +18,7 @@ const About = ({ data }) => {
   console.log(queryClient)
   const query = useQuery(['about', count], () => getProductItem(count), {
     refetchOnWindowFocus: false,
-    // staleTime: 20000,
+    staleTime: 20000,
     initialData: async () => {
       const initialData = await getProductLists()
       console.log(initialData)

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -40,7 +40,7 @@ export const authOptions = {
             image: user.image,
           }
         } else {
-          return null
+          return 'hi'
         }
       },
     }),

--- a/pages/hydrate.js
+++ b/pages/hydrate.js
@@ -4,16 +4,20 @@ import {
   useQuery,
   useQueryClient,
 } from '@tanstack/react-query'
+import Items from 'components/Items'
 import React from 'react'
 import { getProductLists } from 'utils/getProductLists'
 
 const Hydrate = () => {
-  // const { data } = useQuery(['about'], getProductLists)
+  const { data } = useQuery({ queryKey: ['about'], queryFn: getProductLists })
 
   return (
     <>
       <div>hydrate</div>
-      {/* {data} */}
+      {data?.map(item => (
+        <div key={item.id}>{item.name}</div>
+      ))}
+      <Items />
     </>
   )
 }

--- a/pages/hydrate.js
+++ b/pages/hydrate.js
@@ -1,0 +1,33 @@
+import {
+  dehydrate,
+  QueryClient,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
+import React from 'react'
+import { getProductLists } from 'utils/getProductLists'
+
+const Hydrate = () => {
+  // const { data } = useQuery(['about'], getProductLists)
+
+  return (
+    <>
+      <div>hydrate</div>
+      {/* {data} */}
+    </>
+  )
+}
+
+export default Hydrate
+
+export async function getServerSideProps() {
+  const queryClient = new QueryClient()
+
+  await queryClient.prefetchQuery(['about'], () => getProductLists())
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
+}

--- a/pages/query.js
+++ b/pages/query.js
@@ -1,0 +1,18 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import React from 'react'
+import { getProductLists } from 'utils/getProductLists'
+
+const Query = ({ data }) => {
+  const query = useQuery(['about'], () => getProductLists(), {
+    refetchOnWindowFocus: false,
+    initialData: data,
+  })
+  return query.data.map(item => <div key={item.id}>{item.name}</div>)
+}
+
+export default Query
+
+export async function getServerSideProps() {
+  const data = await getProductLists()
+  return { props: { data } }
+}

--- a/utils/useProducts.js
+++ b/utils/useProducts.js
@@ -1,0 +1,8 @@
+import { useQuery } from '@tanstack/react-query'
+import { getProductLists } from './getProductLists'
+
+const useProducts = () => {
+  return useQuery(['about'], () => getProductLists())
+}
+
+export { useProducts }


### PR DESCRIPTION
리엑트 쿼리를 활용하여 서버사이드 랜더링을 구현하기 위해서는
1. getServersideProps 또는 getStaticProps 함수 내부에서 데이터를 fetch하여 컴포넌트로 prop으로 넘겨준 후 usequery의 initialData로 해당 프롭을 넘겨준다.

2. app.js 에서 Hydrate태그를 컴포넌트를 감싸 준 후에 pageProps.dehydratedState 를 Hydrate 태그의 state 요소의 값으로 넘겨준다.
    해당 컴포넌트의 getServersideProps 또는 getStaticProps 함수 내부에서 새로운 클라이언트를 호출하고, 해당 클라이언트에서 prefetch를 해준 후에 해당 클라이언트를 props의 값으로 {dehydrateState: hydrate(클라이언트변수)}를 넘겨주고, 컴포넌트에서 useQuery를 작동하면 서버사이드 랜더링이 완료된다.